### PR TITLE
Add Streamlit serial number finder

### DIFF
--- a/data/serial_numbers.json
+++ b/data/serial_numbers.json
@@ -1,0 +1,8 @@
+{
+  "engine": "ENG-001",
+  "transmission": "TRN-002",
+  "brake pad": "BRK-003",
+  "fuel pump": "FUE-004",
+  "alternator": "ALT-005"
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit

--- a/serialfinder.py
+++ b/serialfinder.py
@@ -1,0 +1,17 @@
+import json
+from typing import Optional, Dict
+
+class SerialNumberFinder:
+    """Simple library to look up car component serial numbers."""
+
+    def __init__(self, data_file: str):
+        self.serials = self._load_serials(data_file)
+
+    def _load_serials(self, data_file: str) -> Dict[str, str]:
+        """Load serial numbers from a JSON data file."""
+        with open(data_file, 'r', encoding='utf-8') as f:
+            return json.load(f)
+
+    def find(self, component: str) -> Optional[str]:
+        """Return the serial number for a component or None if not found."""
+        return self.serials.get(component.lower())

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,17 @@
+import streamlit as st
+from serialfinder import SerialNumberFinder
+
+DATA_FILE = 'data/serial_numbers.json'
+
+finder = SerialNumberFinder(DATA_FILE)
+
+st.title('Car Component Serial Number Finder')
+
+component = st.text_input('Enter the component name')
+if component:
+    serial = finder.find(component)
+    if serial:
+        st.success(f'Serial number for {component}: {serial}')
+    else:
+        st.error('Serial number not found')
+


### PR DESCRIPTION
## Summary
- add `SerialNumberFinder` helper library
- create example JSON dataset of serial numbers
- build `streamlit_app.py` to look up serials
- declare `streamlit` dependency in requirements

## Testing
- `python3 -m py_compile serialfinder.py streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_685cb340c96c83229ebac015478c5174