### PR TITLE
Fix dataset path handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.so
+.Python
+env/
+venv/
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+ENV PORT=8080
+
+CMD ["sh", "-c", "streamlit run streamlit_app.py --server.port ${PORT} --server.address 0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Car Component Serial Number Finder
+
+This repository contains a small Streamlit application for managing cars and their component serial numbers.
+You can compare cars, list their components, add or edit entries, and now delete cars or individual components with confirmation.
+
+## Running locally
+
+```bash
+pip install -r requirements.txt
+streamlit run streamlit_app.py
+```
+
+## Docker
+
+Build the container and run it on port 8080:
+
+```bash
+docker build -t serialfinder .
+docker run -p 8080:8080 serialfinder
+```
+
+The app is designed to work well on Google Cloud Run where the container listens on port `8080`.

--- a/data/serial_numbers.json
+++ b/data/serial_numbers.json
@@ -1,0 +1,18 @@
+{
+  "cars": {
+    "CAR100": ["engine", "transmission", "brake pad"],
+    "CAR200": ["engine", "fuel pump", "alternator"],
+    "CAR300": ["transmission", "brake pad", "fuel pump"],
+    "CAR400": ["engine", "radiator", "alternator"],
+    "CAR500": ["engine", "spark plug", "transmission"]
+  },
+  "components": {
+    "engine": "ENG-001",
+    "transmission": "TRN-002",
+    "brake pad": "BRK-003",
+    "fuel pump": "FUE-004",
+    "alternator": "ALT-005",
+    "radiator": "RAD-006",
+    "spark plug": "SPK-007"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit

--- a/serialfinder.py
+++ b/serialfinder.py
@@ -1,0 +1,66 @@
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+
+class SerialNumberFinder:
+    """Helper to look up cars and component serial numbers."""
+
+    def __init__(self, data_file: Union[str, Path]):
+        self.data_file = Path(data_file)
+        with self.data_file.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        self.cars: Dict[str, List[str]] = {
+            key.upper(): [c.lower() for c in comps]
+            for key, comps in data.get("cars", {}).items()
+        }
+        self.components: Dict[str, str] = {
+            name.lower(): serial for name, serial in data.get("components", {}).items()
+        }
+
+    def get_components(self, car_serial: str) -> Optional[List[str]]:
+        """Return list of component names for a car serial."""
+        return self.cars.get(car_serial.upper())
+
+    def component_serial(self, component: str) -> Optional[str]:
+        """Return serial number for a component name."""
+        return self.components.get(component.lower())
+
+    def add_car(self, car_serial: str, components: List[str]) -> None:
+        """Add a new car with a list of components."""
+        self.cars[car_serial.upper()] = [c.lower() for c in components]
+
+    def add_component_to_car(self, car_serial: str, component: str) -> None:
+        """Add a component to an existing car."""
+        car = car_serial.upper()
+        comp = component.lower()
+        self.cars.setdefault(car, [])
+        if comp not in self.cars[car]:
+            self.cars[car].append(comp)
+
+    def edit_component(self, component: str, serial: str) -> None:
+        """Create or update a component serial number."""
+        self.components[component.lower()] = serial
+
+    def delete_component_from_car(self, car_serial: str, component: str) -> bool:
+        """Delete a component from a car. Returns True if removed."""
+        car = car_serial.upper()
+        comp = component.lower()
+        comps = self.cars.get(car)
+        if comps and comp in comps:
+            comps.remove(comp)
+            return True
+        return False
+
+    def delete_car(self, car_serial: str) -> bool:
+        """Delete a car entirely. Returns True if removed."""
+        car = car_serial.upper()
+        if car in self.cars:
+            del self.cars[car]
+            return True
+        return False
+
+    def save(self) -> None:
+        """Persist data back to the JSON file."""
+        with self.data_file.open("w", encoding="utf-8") as f:
+            json.dump({"cars": self.cars, "components": self.components}, f, indent=2)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,153 @@
+import streamlit as st
+from pathlib import Path
+from serialfinder import SerialNumberFinder
+
+DATA_FILE = Path(__file__).parent / "data" / "serial_numbers.json"
+
+finder = SerialNumberFinder(DATA_FILE)
+
+st.title("Car Component Manager")
+
+MODE_COMPARE = "Compare serial numbers"
+MODE_LIST = "List components for a car"
+MODE_EDIT = "Edit car components"
+MODE_ADD = "Add new car"
+MODE_DELETE = "Delete car or component"
+
+mode = st.selectbox(
+    "Choose action", [MODE_COMPARE, MODE_LIST, MODE_EDIT, MODE_ADD, MODE_DELETE]
+)
+
+if mode == MODE_COMPARE:
+    car1 = st.text_input("Enter first car serial number")
+    car2 = st.text_input("Enter second car serial number")
+
+    if car1 and car2:
+        comps1 = finder.get_components(car1)
+        comps2 = finder.get_components(car2)
+
+        if comps1 is None:
+            st.error(f"Car serial {car1} not found")
+        if comps2 is None:
+            st.error(f"Car serial {car2} not found")
+
+        if comps1 and comps2:
+            set1 = set(comps1)
+            set2 = set(comps2)
+            only1 = set1 - set2
+            only2 = set2 - set1
+            both = set1 & set2
+
+            st.markdown(
+                "<span style='color:red'>Red: only car 1</span>", unsafe_allow_html=True
+            )
+            st.markdown(
+                "<span style='color:blue'>Blue: only car 2</span>",
+                unsafe_allow_html=True,
+            )
+            st.markdown(
+                "<span style='color:green'>Green: both cars</span>",
+                unsafe_allow_html=True,
+            )
+
+            for comp in sorted(only1):
+                serial = finder.component_serial(comp)
+                st.markdown(
+                    f"<span style='color:red'>- {comp} ({serial})</span>",
+                    unsafe_allow_html=True,
+                )
+            for comp in sorted(only2):
+                serial = finder.component_serial(comp)
+                st.markdown(
+                    f"<span style='color:blue'>- {comp} ({serial})</span>",
+                    unsafe_allow_html=True,
+                )
+            for comp in sorted(both):
+                serial = finder.component_serial(comp)
+                st.markdown(
+                    f"<span style='color:green'>- {comp} ({serial})</span>",
+                    unsafe_allow_html=True,
+                )
+
+elif mode == MODE_LIST:
+    car = st.text_input("Enter car serial number")
+    if car:
+        comps = finder.get_components(car)
+        if comps is None:
+            st.error(f"Car serial {car} not found")
+        else:
+            st.subheader(f"Components for {car.upper()}")
+            for comp in comps:
+                serial = finder.component_serial(comp)
+                st.write(f"{comp} - {serial}")
+
+elif mode == MODE_EDIT:
+    car = st.text_input("Enter car serial number to edit")
+    if car:
+        comps = finder.get_components(car)
+        if comps is None:
+            st.error(f"Car serial {car} not found")
+        else:
+            comp = st.selectbox("Select component", comps)
+            current = finder.component_serial(comp) or ""
+            new_serial = st.text_input("Serial number", value=current)
+            if st.button("Update component serial"):
+                finder.edit_component(comp, new_serial)
+                finder.save()
+                st.success("Component updated")
+            new_comp = st.text_input("New component name")
+            new_comp_serial = st.text_input("New component serial")
+            if st.button("Add component to car") and new_comp and new_comp_serial:
+                finder.add_component_to_car(car, new_comp)
+                finder.edit_component(new_comp, new_comp_serial)
+                finder.save()
+                st.success("Component added")
+
+elif mode == MODE_ADD:
+    car = st.text_input("New car serial")
+    comps = st.text_area('Components and serials (one per line "component,serial")')
+    if st.button("Add car") and car and comps:
+        comp_list = []
+        for line in comps.splitlines():
+            if "," in line:
+                name, serial = [p.strip() for p in line.split(",", 1)]
+                comp_list.append(name)
+                finder.edit_component(name, serial)
+        if comp_list:
+            finder.add_car(car, comp_list)
+            finder.save()
+            st.success(f"Car {car} added")
+        else:
+            st.error("No valid components provided")
+
+elif mode == MODE_DELETE:
+    choice = st.radio("Delete target", ["Car", "Component from car"])
+    if choice == "Car":
+        with st.form("delete_car"):
+            car = st.text_input("Car serial to delete")
+            confirm = st.checkbox("I confirm deletion")
+            submitted = st.form_submit_button("Delete car")
+            if submitted:
+                if confirm:
+                    if finder.delete_car(car):
+                        finder.save()
+                        st.success(f"Car {car} deleted")
+                    else:
+                        st.error("Car not found")
+                else:
+                    st.warning("Deletion not confirmed")
+    else:
+        with st.form("delete_component"):
+            car = st.text_input("Car serial")
+            component = st.text_input("Component name to delete")
+            confirm = st.checkbox("I confirm deletion")
+            submitted = st.form_submit_button("Delete component")
+            if submitted:
+                if confirm:
+                    if finder.delete_component_from_car(car, component):
+                        finder.save()
+                        st.success("Component deleted")
+                    else:
+                        st.error("Car or component not found")
+                else:
+                    st.warning("Deletion not confirmed")


### PR DESCRIPTION
## Summary
- allow `SerialNumberFinder` to accept a `Path` and open files via `Path` methods
- resolve the dataset path in the Streamlit app relative to the file location

## Testing
- `python3 -m py_compile serialfinder.py streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_685cb340c96c83229ebac015478c5174